### PR TITLE
fix: missing type definition file on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Florian Reuschel <florian@loilo.de>",
   "files": [
     "index.js",
+    "index.d.ts",
     "README.md"
   ],
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "README.md"
   ],
   "main": "index.js",
-  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Loilo/composite-symbol.git"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "README.md"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Loilo/composite-symbol.git"


### PR DESCRIPTION
<del>Just add `"types"` field to `package.json`.</del>

Add `index.d.ts` to `files` field.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html